### PR TITLE
Añadir select general en cupones

### DIFF
--- a/src/app/features/coupons/data/couponsDataRepository.ts
+++ b/src/app/features/coupons/data/couponsDataRepository.ts
@@ -76,4 +76,15 @@ export class CouponsDataRepository implements CouponsRepository {
         )
       })
     }
+
+    getAvailableYears(): Observable<string[]> {
+      return new Observable(obs => {
+        this.dataSource.getAvailableYears().then(total => {
+          obs.next(total);
+          obs.complete();
+        }).catch((error) =>
+          obs.error(error)
+        )
+      })
+    }
 }

--- a/src/app/features/coupons/data/remote/couponsApiSource.service.ts
+++ b/src/app/features/coupons/data/remote/couponsApiSource.service.ts
@@ -86,4 +86,15 @@ export class CouponsApiSourceService{
       }
     }
 
+    async getAvailableYears():Promise<string[]>{
+      try {
+          const response = await fetch(`${this.url}cuponesAvailableYears`);
+          const data = await response.json();
+          return data.map( (years: {year: string;}) => years.year );
+      }
+      catch (error) {
+        throw new Error("Error al recoger los datos");
+      }
+  }
+
 }

--- a/src/app/features/coupons/domain/repositories/coupons.repository.ts
+++ b/src/app/features/coupons/domain/repositories/coupons.repository.ts
@@ -8,4 +8,5 @@ export interface CouponsRepository {
   getTotalCouponsByMonth(month: string, year: string): Observable<number>;
   getTotalDiscountByMonth(month: string, year: string): Observable<number>;
   getMonthlyCouponsByYear(year: string): Observable<number[]>
+  getAvailableYears(): Observable<string[]>
 }

--- a/src/app/features/coupons/domain/useCases/GetCouponsAvailableYearsUseCase.ts
+++ b/src/app/features/coupons/domain/useCases/GetCouponsAvailableYearsUseCase.ts
@@ -1,0 +1,13 @@
+import {Observable} from "rxjs";
+import {CouponsRepository} from "../repositories/coupons.repository";
+
+export class GetCouponsAvailableYearsUseCase {
+
+  constructor(private couponService: CouponsRepository) {}
+
+
+  execute(): Observable<string[]> {
+      return this.couponService.getAvailableYears()
+  }
+
+}

--- a/src/app/features/coupons/presentation/main-coupons/components/coupon-box/coupon-box.component.html
+++ b/src/app/features/coupons/presentation/main-coupons/components/coupon-box/coupon-box.component.html
@@ -44,21 +44,8 @@
   </ng-container>
 
   <ng-container *ngSwitchCase="'couponsMonth'">
-    <div>
-      <h3 class="coupons-box-title">Nº cupones mensuales</h3>
-      <div>
-        <select [value]="selectedMonth" [(ngModel)]="selectedMonth" (change)="changeDate()">
-          <option *ngFor="let month of months" [value]="month">
-            {{ month }}
-          </option>
-        </select>
-        <select [value]="selectedYear" [(ngModel)]="selectedYear" (change)="changeDate()">
-          <option *ngFor="let year of years" [value]="year">
-            {{ year }}
-          </option>
-        </select>
-      </div>
-    </div>
+    <h3 class="coupons-box-title">Nº cupones mensuales</h3>
+
 
     <div *ngIf="viewModel.isLoadingCouponsMonth()" class="loading-state">
       <div class="spinner"></div>
@@ -81,21 +68,7 @@
   </ng-container>
 
   <ng-container *ngSwitchCase="'discountMonth'">
-    <div>
-      <h3 class="coupons-box-title">Descuento mensual</h3>
-      <div>
-        <select [value]="selectedMonth" [(ngModel)]="selectedMonth" (change)="changeDate()">
-          <option *ngFor="let month of months" [value]="month">
-            {{ month }}
-          </option>
-        </select>
-        <select [value]="selectedYear" [(ngModel)]="selectedYear" (change)="changeDate()">
-          <option *ngFor="let year of years" [value]="year">
-            {{ year }}
-          </option>
-        </select>
-      </div>
-    </div>
+    <h3 class="coupons-box-title">Descuento mensual</h3>
 
     <div *ngIf="viewModel.isLoadingDiscountMonth()" class="loading-state">
       <div class="spinner"></div>

--- a/src/app/features/coupons/presentation/main-coupons/components/coupon-box/coupon-box.component.scss
+++ b/src/app/features/coupons/presentation/main-coupons/components/coupon-box/coupon-box.component.scss
@@ -51,23 +51,6 @@ h3 {
   color: red;
 }
 
-.coupons-box div:first-child {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-}
-
-.coupons-box div:first-child input {
-  width: 120px;
-}
-
-select {
-  padding-left: 4px;
-  padding-right: 4px;
-  height: 32px;
-  margin-left: 5px;
-}
-
 .spinner {
   width: 16px;
   height: 16px;

--- a/src/app/features/coupons/presentation/main-coupons/components/coupon-box/coupon-box.component.ts
+++ b/src/app/features/coupons/presentation/main-coupons/components/coupon-box/coupon-box.component.ts
@@ -13,17 +13,9 @@ import {BoxCouponsViewModel} from './coupons-box.view-model';
 export class CouponBoxComponent implements OnInit {
   boxType = input.required<"coupons" | "discount" | "couponsMonth" | "discountMonth">()
   viewModel = inject(BoxCouponsViewModel)
-  date = new Date().toISOString().substring(0, 7);
-  selectedYear: string = new Date().getFullYear() + "";
-  selectedMonth: string = '';
-  years = Array.from({length: 5}, (_, i) => new Date().getFullYear() - i);
-  months = ["01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12"]
 
   ngOnInit(): void {
-    const fechaActual = new Date();
-    const mesActual = (fechaActual.getMonth() + 1).toString().padStart(2, '0');
 
-    this.selectedMonth = mesActual
     switch (this.boxType()) {
       case "coupons":
         this.viewModel.getTotalCoupons();
@@ -33,27 +25,7 @@ export class CouponBoxComponent implements OnInit {
         this.viewModel.getTotalDiscount();
         break;
 
-      case "couponsMonth":
-        this.changeDate();
-        break;
-
-      case "discountMonth":
-        this.changeDate();
-        break;
     }
   }
 
-  changeDate() {
-    switch (this.boxType()) {
-      case "couponsMonth":
-        this.viewModel.getTotalCouponsByMonth(this.selectedMonth, this.selectedYear);
-        break;
-
-      case "discountMonth":
-        this.viewModel.getTotalDiscountByMonth(this.selectedMonth, this.selectedYear);
-        break;
-    }
-
-
-  }
 }

--- a/src/app/features/coupons/presentation/main-coupons/components/coupon-count-graphic/coupon-count-graphic.component.html
+++ b/src/app/features/coupons/presentation/main-coupons/components/coupon-count-graphic/coupon-count-graphic.component.html
@@ -1,11 +1,6 @@
 <div class="chart-container">
   <div class="header">
     <h3>Cupones usados por mes</h3>
-    <select [(ngModel)]="selectedYear" (change)="yearChange()">
-      <option *ngFor="let year of years" [value]="year">
-        {{year}}
-      </option>
-    </select>
   </div>
 
   <div *ngIf="viewModel.isLoading()" class="loading-state">

--- a/src/app/features/coupons/presentation/main-coupons/components/coupon-count-graphic/coupon-count-graphic.component.scss
+++ b/src/app/features/coupons/presentation/main-coupons/components/coupon-count-graphic/coupon-count-graphic.component.scss
@@ -6,8 +6,6 @@ h3 {
 }
 
 .header {
-  display: flex;
-  justify-content: space-between;
   margin-bottom: 16px;
 }
 

--- a/src/app/features/coupons/presentation/main-coupons/components/coupon-count-graphic/coupon-count-graphic.component.ts
+++ b/src/app/features/coupons/presentation/main-coupons/components/coupon-count-graphic/coupon-count-graphic.component.ts
@@ -17,8 +17,6 @@ import {CouponCountGraphicViewModel} from './coupon-count-graphic.view-model';
 export class CouponCountGraphicComponent implements AfterViewInit {
   viewModel = inject(CouponCountGraphicViewModel)
   @ViewChild('chartCanvas') chartCanvas!: ElementRef;
-  selectedYear: string = new Date().getFullYear() + "";
-  years = Array.from({length: 5}, (_, i) => new Date().getFullYear() - i);
   private isPlatformBrowser: boolean;
   private chart: any;
 
@@ -34,8 +32,6 @@ export class CouponCountGraphicComponent implements AfterViewInit {
   }
 
   ngAfterViewInit() {
-    this.yearChange()
-
 
   }
 
@@ -43,6 +39,7 @@ export class CouponCountGraphicComponent implements AfterViewInit {
     if (this.chart) {
       this.chart.destroy();
     }
+    if(!isPlatformBrowser) return;
 
     const ctx = this.chartCanvas.nativeElement.getContext('2d');
 
@@ -76,7 +73,4 @@ export class CouponCountGraphicComponent implements AfterViewInit {
     });
   }
 
-  yearChange() {
-    this.viewModel.getTotalCoupons(this.selectedYear)
-  }
 }

--- a/src/app/features/coupons/presentation/main-coupons/components/coupons-table/coupons-table.component.scss
+++ b/src/app/features/coupons/presentation/main-coupons/components/coupons-table/coupons-table.component.scss
@@ -33,6 +33,11 @@ h3 {
     unicode-bidi: isolate;
 }
 
+.coupons-table {
+  overflow-y: auto;
+  max-height: 675px;
+}
+
 .mat-mdc-table {
   background-color: #fff;
 }

--- a/src/app/features/coupons/presentation/main-coupons/main-coupons.component.html
+++ b/src/app/features/coupons/presentation/main-coupons/main-coupons.component.html
@@ -1,4 +1,25 @@
 <div class="coupon-container">
+  <div class="coupon-header">
+    <h2>Cupones</h2>
+
+    <div class="coupon-date-selector">
+      <mat-form-field appearance="outline">
+        <mat-select [(ngModel)]="selectedMonth" (selectionChange)="onDateChange()">
+          <mat-option *ngFor="let month of months; let i = index" [value]="i + 1">
+            {{getMonthName(i + 1)}}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+      <mat-form-field appearance="outline">
+        <mat-select [(ngModel)]="selectedYear" (selectionChange)="onDateChange()">
+          <mat-option *ngFor="let year of years" [value]="year">
+            {{year}}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+    </div>
+  </div>
+
   <div class="coupon-element coupons-table">
     <app-coupons-table />
   </div>

--- a/src/app/features/coupons/presentation/main-coupons/main-coupons.component.scss
+++ b/src/app/features/coupons/presentation/main-coupons/main-coupons.component.scss
@@ -1,3 +1,23 @@
+.coupon-container {
+  margin: 0 1%;
+}
+
+.coupon-header {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  > * {
+    margin: 0 0.5%;
+  }
+}
+
+.coupon-date-selector {
+  display: flex;
+  gap: 16px;
+}
+
 .coupon-element {
   background: #fff;
   border-radius: 8px;
@@ -8,7 +28,6 @@
 
 .coupon-container {
   display: flex;
-  align-items: flex-start;
   flex-wrap: wrap;
 }
 
@@ -26,7 +45,7 @@
 .coupon-box {
   width: 48%;
   margin: 1%;
-  min-height: 125px;
+  height: 125px;
 }
 
 .coupon-graphic {

--- a/src/app/features/coupons/presentation/main-coupons/main-coupons.component.ts
+++ b/src/app/features/coupons/presentation/main-coupons/main-coupons.component.ts
@@ -1,14 +1,56 @@
-import {Component} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {Component,effect,inject} from '@angular/core';
+import {FormsModule} from '@angular/forms';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatSelectModule} from '@angular/material/select';
+import {CouponBoxComponent} from "./components/coupon-box/coupon-box.component";
+import {BoxCouponsViewModel} from './components/coupon-box/coupons-box.view-model';
+import {CouponCountGraphicComponent} from "./components/coupon-count-graphic/coupon-count-graphic.component";
+import {CouponCountGraphicViewModel} from './components/coupon-count-graphic/coupon-count-graphic.view-model';
 import {CouponsTableComponent} from "./components/coupons-table/coupons-table.component";
-import { CouponBoxComponent } from "./components/coupon-box/coupon-box.component";
-import { CouponCountGraphicComponent } from "./components/coupon-count-graphic/coupon-count-graphic.component";
+import {MainCouponsViewModel} from './main-coupons.viewModel';
 
 @Component({
   selector: 'app-main-coupons',
-  imports: [CouponsTableComponent, CouponBoxComponent, CouponCountGraphicComponent],
+  imports: [
+    CommonModule,
+    CouponsTableComponent,
+    CouponBoxComponent,
+    CouponCountGraphicComponent,
+    MatSelectModule,
+    MatFormFieldModule,
+    FormsModule
+  ],
   templateUrl: './main-coupons.component.html',
   styleUrl: './main-coupons.component.scss'
 })
 export class MainCouponsComponent  {
+  selectedMonth: number = new Date().getMonth() + 1;
+  selectedYear: string = new Date().getFullYear().toString();
+  years: string[] = [];
+  months: number[] = Array.from({length: 12}, (_, i) => i + 1);
 
+  viewModel = inject(MainCouponsViewModel)
+  boxViewModel = inject(BoxCouponsViewModel)
+  countGraphicViewModel = inject(CouponCountGraphicViewModel)
+
+  constructor() {
+    this.viewModel.getYearsAvailable()
+    effect(() => {
+      this.years = this.viewModel.years()
+    });
+    this.onDateChange()
+  }
+
+  getMonthName(month: number): string {
+    return new Date(2000, month - 1, 1).toLocaleString('es-ES', { month: 'long' });
+  }
+
+  onDateChange(): void {
+    const monthString = this.selectedMonth.toString().padStart(2, '0');
+
+    this.boxViewModel.getTotalCouponsByMonth(monthString, this.selectedYear.toString())
+    this.boxViewModel.getTotalDiscountByMonth(monthString, this.selectedYear.toString())
+    this.countGraphicViewModel.getTotalCoupons(this.selectedYear)
+  }
 }

--- a/src/app/features/coupons/presentation/main-coupons/main-coupons.viewModel.ts
+++ b/src/app/features/coupons/presentation/main-coupons/main-coupons.viewModel.ts
@@ -1,0 +1,51 @@
+import {Injectable,computed,signal} from "@angular/core";
+import {CouponsDataRepository} from "../../data/couponsDataRepository";
+import {GetCouponsAvailableYearsUseCase} from "../../domain/useCases/GetCouponsAvailableYearsUseCase";
+
+
+export interface TotalUIState {
+  error: string | null;
+  years: string[];
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class MainCouponsViewModel {
+
+  private getCouponsAvailableYearsUseCase: GetCouponsAvailableYearsUseCase;
+
+  constructor(private couponsDataRepository: CouponsDataRepository) {
+    this.getCouponsAvailableYearsUseCase = new GetCouponsAvailableYearsUseCase(this.couponsDataRepository);
+  }
+
+
+  private uiState = signal<TotalUIState>({
+    years: [],
+    error: null
+  });
+
+  readonly years = computed(() => this.uiState().years);
+  readonly error = computed(() => this.uiState().error);
+
+  getYearsAvailable(): void {
+
+    this.getCouponsAvailableYearsUseCase.execute().subscribe(
+      {
+        next: (total) => {
+          this.uiState.update(() => ({
+            years: total,
+            error: null
+          }));
+        },
+        error: (error) => {
+          this.uiState.update(() => ({
+            years: [],
+            error: error.message
+          }));
+        }
+      }
+    )
+  }
+
+}


### PR DESCRIPTION
## 🤔 Descripción del problema a resolver
Cambiar el selector de fecha de las cajas y el gráfico a uno general de la pantalla

## 💡 Proceso seguido para resolver el problema.
Se ha añadido el selector de fecha en cupones.

## 📝 Pruebas de validación
Se ha comprobado que al modificar la fecha del selector se muestran los datos correctamente.

## 👩‍💻 Resumen de los cambios introducidos
Se ha añadido el selector de fecha en cupones.
Se han eliminado los selectores de fecha de las cajas y del gráfico

## 📸 Screenshot o Video
![image](https://github.com/user-attachments/assets/27eb0074-7836-4182-96dd-d492070279cd)

## ✅ Checklist
- [x] La rama tiene el formato correcto: tipo_de_issue/numero_issue/descripcion.
- [x] He añadido un título a la PR descriptivo.
- [x] Me he asignado como autor.
- [x] He asignado a dos revisores.
- [x] He relacionado la PR con la Issue.
